### PR TITLE
update links in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Website: https://votion.dev
 
 Need to install Dashactyl? Need API documentations? Need a place to find themes?
 
-Check out the wiki! https://github.com/Votion-Development/Dashactyl/wiki
+Check out the wiki! https://docs.votion.dev/docs/Dashactyl/introduction
 
 # Disclaimer
 


### PR DESCRIPTION
this pull request includes the following:

- Change documentation link


Hello! I've seen that the wiki link on the readme leads to an never ending loop of the readme page, this pull request should change that and bring you to the docs
