### PR TITLE
Added registered role

### DIFF
--- a/handlers/oauth2.js
+++ b/handlers/oauth2.js
@@ -81,6 +81,7 @@ module.exports.load = async function (app, ifValidAPI, ejs) {
       userinfo.guilds = guilds
 
       if (process.env.discord.guild) {
+
         const check_if_banned = (await fetch(
         `https://discord.com/api/guilds/${process.env.discord.guild}/bans/${userinfo.id}`,
         {
@@ -110,6 +111,18 @@ module.exports.load = async function (app, ifValidAPI, ejs) {
           )
         } else {
           console.log('[AUTO JOIN SERVER] For some reason, the status code is ' + check_if_banned + ', instead of 200 or 404. You should worry about this.')
+        }
+        if (process.env.discord.registeredrole) {
+          await fetch(
+                `https://discord.com/api/guilds/${process.env.discord.guild}/members/${userinfo.id}/roles/${process.env.discord.registeredrole}`,
+                {
+                  method: "put",
+                  headers: {
+                    'Content-Type': 'application/json',
+                    "Authorization": `Bot ${newsettings.api.client.bot.token}`
+                  }
+                }
+              );
         }
       };
 

--- a/settings-template.yml
+++ b/settings-template.yml
@@ -8,11 +8,11 @@ website:
   secure: false # This option requires https.
 
 auditlogs: # This feature enable auditlogs for dashactyl v1
-  enabled: true # enable or disable the Audit Logs
+  enabled: false # enable or disable the Audit Logs
   webhook_url: "Enter your webhook URL"
 
 email_system: # This feature enable email system for Dashactyl v1
-  enabled: true # enable or disable the email system
+  enabled: false # enable or disable the email system
   smtp_host: "Enter your SMTP Host" # You need to put here your smtp host from your email software (gmail, zoho, etc.) like smtp.zoho.com
   smtp_port: "Enter your SMTP Port" # Put the port of your smtp host like 465
   smtp_user: "Enter your SMTP User" # Your email like nohaxito@mydomain.gg
@@ -29,6 +29,7 @@ discord:
 
   token: "Insert your bot token here."
   guild: "000000000000000000" # Add your server ID you want to force users to join on login here.
+  registeredrole: "000000000000000000" # Add the ID of the role you want to be granted when logging into the dashboard.
 
 pterodactyl:
   domain: "Enter your Pterodactyl Panel domain here."


### PR DESCRIPTION
Hello! I make this PR with some changes which are:

[/] Audit logs via webhooks have been set to be disabled by default.

[/] Email notifications have been set to be disabled by default.

[+] Added option to put role id in `settings.yml` file which will be the one that will be given to the user once they log in to the dashboard (if they are inside the server which has been placed in `settings.yml`).

If you have any problems or questions, you can find me on the VotionDevelopment Discord, my username is NoHaxito#8711.